### PR TITLE
fixed Ladybug configuration options

### DIFF
--- a/DependencyInjection/RaulFraileLadybugExtension.php
+++ b/DependencyInjection/RaulFraileLadybugExtension.php
@@ -23,11 +23,7 @@ class RaulFraileLadybugExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        foreach ($config as $rootKey => $configurationSettings) {
-            foreach ($configurationSettings as $configKey => $configValue) {
-                ladybug_set(sprintf('%s.%s', $rootKey, $configKey), $configValue);
-            }
-        }
+        $container->setParameter('raul_fraile_ladybug.configs', $config);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/EventListener/LadybugConfigListener.php
+++ b/EventListener/LadybugConfigListener.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace RaulFraile\Bundle\LadybugBundle\EventListener;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+class LadybugConfigListener
+{
+    protected $ladybugConfigs;
+
+    public function __construct($ladybugConfigs)
+    {
+        $this->ladybugConfigs = $ladybugConfigs;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        foreach ($this->ladybugConfigs as $rootKey => $configurationSettings) {
+            foreach ($configurationSettings as $configKey => $configValue) {
+                ladybug_set(sprintf('%s.%s', $rootKey, $configKey), $configValue);
+            }
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,6 +14,11 @@
             <tag name="data_collector" template="RaulFraileLadybugBundle:Collector:ladybug" id="ladybug" />
         </service>
 
+        <service id="ladybug.event_listener.ladybug_config_listener" class="RaulFraile\Bundle\LadybugBundle\EventListener\LadybugConfigListener">
+        	<argument>%raul_fraile_ladybug.configs%</argument>
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+        </service>
+
         <service id="ladybug" alias="data_collector.ladybug_data_collector" />
     </services>
 </container>


### PR DESCRIPTION
This closes Issue #13 

The problem was that the Ladybug Dumper needs the configs to be set on each application page load, but we were setting the options in the bundle extension during the service container build.

Instead, I took the config and added them as a paramater in the container, and on each kernel request we set the options via a listener to the kernel.request event.
