### PR TITLE
Correct ladybug_set to ladybug_set_option

### DIFF
--- a/DependencyInjection/RaulFraileLadybugExtension.php
+++ b/DependencyInjection/RaulFraileLadybugExtension.php
@@ -25,7 +25,7 @@ class RaulFraileLadybugExtension extends Extension
 
         foreach ($config as $rootKey => $configurationSettings) {
             foreach ($configurationSettings as $configKey => $configValue) {
-                ladybug_set(sprintf('%s.%s', $rootKey, $configKey), $configValue);
+                ladybug_set_option(sprintf('%s.%s', $rootKey, $configKey), $configValue);
             }
         }
 


### PR DESCRIPTION
I have detect that when I set config parameters in config.yml show this error:

FatalErrorException: Error: Call to undefined function RaulFraile\Bundle\LadybugBundle\DependencyInjection\ladybug_set() in /Users/jl/php_projects/responsive/vendor/raulfraile/ladybug-bundle/RaulFraile/Bundle/LadybugBundle/DependencyInjection/RaulFraileLadybugExtension.php line 28

For this reason I have changed the ladybug_set() at line 28 by ladybug_set_options()

Thanks for this great tool.
