### PR TITLE
made object_max_nexting_level and array_max_nesting_level overwriteable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,6 +21,8 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('theme')->defaultValue('modern')->end()
+                ->scalarNode('array_max_nesting_level')->defaultValue(5)->end()
+                ->scalarNode('object_max_nesting_level')->defaultValue(3)->end()
                 ->scalarNode('expanded')->defaultValue(false)->end()
                 ->scalarNode('silenced')->defaultValue(false)->end()
             ->end();


### PR DESCRIPTION
The `array_max_nesting_level` and `object_max_nesting_level` values were not configurable
