### PR TITLE
Updated gitignore to ignore these files/folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-nbproject
-.idea
+composer.lock
+composer.phar
+vendor
+phpunit.xml


### PR DESCRIPTION
- vendor/
- phpunit.xml
- composer.lock
- composer.phar

editor specific files should not be added in gitignore in order to be added
in the global gitignore file.
