### PR TITLE
fixing "Undefined index: vars" in symfony 2.6 debug toolbar

### DIFF
--- a/DataCollector/LadybugDataCollector.php
+++ b/DataCollector/LadybugDataCollector.php
@@ -55,7 +55,7 @@ class LadybugDataCollector extends DataCollector
      */
     public function getVars()
     {
-        return $this->data['vars'];
+        return isset($this->data['vars'])?$this->data['vars']:array();
     }
 
     /**


### PR DESCRIPTION
somehow this worked before upgrading to symfony 2.6, but this check looks necessary
