### PR TITLE
Readme: simplify install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,10 @@ Getting as a result:
 
 ### Step 1: Composer
 
-Add the following line to the `composer.json` file:
-
-``` json
-{
-    "require": {
-        "raulfraile/ladybug-bundle": "~1.0"
-    }
-}
-```
-To actually install Ladybug in your project, download the composer binary and run it:
+Install via composer:
 
 ``` bash
-wget http://getcomposer.org/composer.phar
-# or
-curl -O http://getcomposer.org/composer.phar
-
-php composer.phar install
+composer require raulfraile/ladybug-bundle
 ```
 
 ### Step 2: Enable the bundle


### PR DESCRIPTION
- composer is standard nowadays
- this also support newer versions, as compose pick the most recent that meets he requirements
